### PR TITLE
Fix formula duplication to clone materials, refresh timestamp, and handle missing lists

### DIFF
--- a/app.js
+++ b/app.js
@@ -594,7 +594,9 @@ function duplicateFormula(id) {
   const clone = {
     ...formula,
     id: `formula-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-    name: `${formula.name} (copia)`
+    name: `${formula.name} (copia)`,
+    updatedAt: new Date().toISOString(),
+    materials: (formula.materials || []).map((item) => ({ ...item })),
   };
   state.formulas.push(clone);
   persistLibrary();


### PR DESCRIPTION
## Summary
- ensure duplicated formulas create new material copies to avoid shared references
- set duplicated formulas to update their timestamps so date sorting surfaces them immediately
- preserve persistence and rendering calls to refresh the library display
- guard duplication against formulas missing materials to avoid runtime errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa14fbed4832286c7cc899cff219e