### PR TITLE
Add Excel and PDF export options

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,18 @@
         <div id="libraryList" class="library"></div>
       </section>
 
+      <section class="card export-card" id="exportSection">
+        <h2>Esporta report</h2>
+        <p class="microcopy">
+          Scarica una copia strutturata della formula corrente per condividerla con il tuo team o
+          archiviarla offline.
+        </p>
+        <div class="export-actions">
+          <button id="exportExcelBtn" type="button">Esporta Excel</button>
+          <button id="exportPdfBtn" class="ghost-btn" type="button">Esporta PDF</button>
+        </div>
+      </section>
+
       <footer class="microcopy">
         I dati restano sul tuo dispositivo (localStorage). Esporta per condividere o archiviare.
       </footer>

--- a/styles.css
+++ b/styles.css
@@ -280,6 +280,21 @@ button.ghost-btn {
   margin-top: 1rem;
 }
 
+.export-card .microcopy {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.export-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.export-actions button {
+  min-width: 160px;
+}
+
 footer.microcopy {
   text-align: center;
   margin-top: 3rem;


### PR DESCRIPTION
## Summary
- add a bottom-page export section with buttons for Excel and PDF downloads
- implement client-side generators for Excel (.xls) and PDF exports using the current formula data
- share helper utilities for safe filenames, HTML escaping, and binary download handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd6a80138c8322afb31d3a9feff89e